### PR TITLE
Fix missing xAPI verb

### DIFF
--- a/goals-assessment-page.js
+++ b/goals-assessment-page.js
@@ -421,7 +421,7 @@ H5P.GoalsAssessmentPage = (function ($, EventDispatcher) {
    * @see contract at {@link https://h5p.org/documentation/developers/contracts#guides-header-6}
    */
   GoalsAssessmentPage.prototype.getXAPIData = function () {
-    var xAPIEvent = this.createXAPIEventTemplate('compound');
+    var xAPIEvent = this.createXAPIEventTemplate('answered');
     this.addQuestionToXAPI(xAPIEvent);
     return {
       statement: xAPIEvent.data.statement,


### PR DESCRIPTION
`createXAPIEventTemplate` is passed '_compound_' as an argument which is not a verb. This will eventually cause the resulting xAPI  statement to be invalid, because '_compound_' obviously is not a verb is also not in the list of allowed verbs for template (https://github.com/h5p/h5p-php-library/blob/1a644dda1134b1ce60635db8d0ab5f09caaa03e4/js/h5p-x-api-event.js#L298-L331).

If merged in, the Goals Assessment Page will use '_answererd_' instead.